### PR TITLE
chore: copy CNAME to the repo root

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+tour.tact-lang.org


### PR DESCRIPTION
This might enable correct name resolution on GitHub Pages.

Towards #27.